### PR TITLE
Register Correct Plugin Name and Update Roku-client Dependency to v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -981,9 +981,9 @@
       "dev": true
     },
     "fetch-ponyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.0.tgz",
-      "integrity": "sha512-bLc7JCjpJZZUXVxbgwUhd72Q19MAokrCXOg/Akq+wl0uFLFLklFdBkZo5OpQ3kLI0oGqrKdx6t5Zo3QwXBRmbQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.1.tgz",
+      "integrity": "sha512-rWLgTr5A44/XhvCQPYj0X9Tc+cjUaHofSM4lcwjc9MavD5lkjIhJ+h8JQlavPlTIgDpwhuRozaIykBvX9ItaSA==",
       "requires": {
         "node-fetch": "~2.6.0"
       }
@@ -1706,16 +1706,6 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
-    "lodash.reduce": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
-    },
-    "lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
-    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -2196,15 +2186,13 @@
       }
     },
     "roku-client": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/roku-client/-/roku-client-3.2.0.tgz",
-      "integrity": "sha512-VGwKx0JQD2lRXvBYMBoJ+ia/cKIptxWn1Na+XJ/6OWGAMbp7PiskqP6IJZlrNslnrn9e8GaQ88bmYFRPoPwI2w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/roku-client/-/roku-client-4.0.0.tgz",
+      "integrity": "sha512-TKHFeYFpWEu2x8k635V4UCixTd2jUeTrxGV7EvEHj+UglVd5B4NT4Q58Lj3b4S0ahT9QdIuIJGahbESZj/ClHw==",
       "requires": {
         "debug": "^4.1.1",
         "fetch-ponyfill": "^6.1.0",
         "lodash.camelcase": "^4.3.0",
-        "lodash.reduce": "^4.6.0",
-        "lodash.values": "^4.3.0",
         "node-ssdp": "^4.0.0",
         "xml2js": "^0.4.23"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "homebridge"
   ],
   "dependencies": {
-    "roku-client": "^3.2.0"
+    "roku-client": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^13.13.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,5 @@ import { RokuTvPlatform } from "./roku-tv-platform";
  * This method registers the platform with Homebridge
  */
 export = (api: API) => {
-  api.registerPlatform("homebridge-roku-tv", PLATFORM_NAME, RokuTvPlatform);
+  api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, RokuTvPlatform);
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { API } from "homebridge";
 
 import { PLATFORM_NAME } from "./settings";
+import { PLUGIN_NAME } from "./settings";
 import { RokuTvPlatform } from "./roku-tv-platform";
 
 /**

--- a/src/roku-tv-platform.ts
+++ b/src/roku-tv-platform.ts
@@ -39,7 +39,7 @@ export class RokuTvPlatform implements DynamicPlatformPlugin {
       log.debug("Executed didFinishLaunching callback");
       this.discoverDevices()
         .then()
-        .catch((e) => this.log.error(e));
+        .catch((e) => this.log.debug(e));
     });
   }
 


### PR DESCRIPTION
@JarekToro, This is what is logging in Debug mode, last PR registered wrong plugin name.

This will fix that!

```Plugin 'homebridge-roku-tv-plugin' tried to register with an incorrect plugin identifier: 'homebridge-roku-tv'. Please report this to the developer!```